### PR TITLE
Handle error due to missing quad precission

### DIFF
--- a/gftool/lattice/bethe.py
+++ b/gftool/lattice/bethe.py
@@ -9,7 +9,7 @@ DOS.
 """
 import numpy as np
 
-_PRECISE_TYPES = {np.dtype(np.complex256), np.dtype(np.float128)}
+from gftool.precision import PRECISE_TYPES as _PRECISE_TYPES
 
 
 def gf_z(z, half_bandwidth):

--- a/gftool/pade.py
+++ b/gftool/pade.py
@@ -26,7 +26,7 @@ from itertools import islice
 
 import numpy as np
 
-from . import Result
+from gftool import Result
 from gftool.precision import PRECISE_TYPES as _PRECISE_TYPES
 
 LOGGER = logging.getLogger(__name__)

--- a/gftool/pade.py
+++ b/gftool/pade.py
@@ -27,11 +27,10 @@ from itertools import islice
 import numpy as np
 
 from . import Result
+from gftool.precision import PRECISE_TYPES as _PRECISE_TYPES
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.NullHandler())
-
-_PRECISE_TYPES = {np.dtype(np.complex256), np.dtype(np.float128)}
 
 
 class KindSelector(ABC):

--- a/gftool/precision.py
+++ b/gftool/precision.py
@@ -1,0 +1,23 @@
+"""Helper to temporarily increase working precision for calculations.
+
+Note that in windows no quad-precision is available.
+
+"""
+import warnings
+
+import numpy as np
+
+try:
+    # pylint: disable=pointless-statement
+    np.complex256
+    np.float128
+except AttributeError:
+    HAS_QUAD = False
+    warnings.warn("No quad precision datatypes available!\n"
+                  "Some functions might be less accurate.")
+    np.float128 = np.longfloat
+    np.complex256 = np.clongfloat
+else:
+    HAS_QUAD = True
+
+PRECISE_TYPES = {np.dtype(np.longfloat), np.dtype(np.clongfloat)}


### PR DESCRIPTION
For now, we just issue a warning once, that there is no quad-precission and consequently fake it.