### PR TITLE
Fix tests on Windows

### DIFF
--- a/gftool/tests/cpa_test.py
+++ b/gftool/tests/cpa_test.py
@@ -11,6 +11,7 @@ from hypothesis_gufunc.gufunc import gufunc_args
 
 from .context import gftool as gt
 
+HAS_QUAD = gt.precision.HAS_QUAD
 
 ignore_close_to_root = pytest.mark.filterwarnings(
     "ignore:(invalid value encountered in double_scalars):RuntimeWarning"
@@ -20,8 +21,11 @@ ignore_illconditioned = pytest.mark.filterwarnings(
 )
 
 
-@given(gufunc_args('(n)->(n)', dtype=np.complex_,
-                   elements=st.complex_numbers(allow_infinity=False, allow_nan=False)))
+@given(gufunc_args(
+    '(n)->(n)', dtype=np.complex_,
+    elements=st.complex_numbers(allow_infinity=False, allow_nan=False,
+                                max_magnitude=None if HAS_QUAD else 1e100)
+))
 def test_trival_cmpt_gf(args):
     """Test component Green's function for trivial case `concentration=1`."""
     z, = args

--- a/gftool/tests/greenfunctions_test.py
+++ b/gftool/tests/greenfunctions_test.py
@@ -858,8 +858,8 @@ def test_bethe_derivative_2(z, D):
     assert np.allclose(gf_d1, fct_d1(z))
 
 
-@given(z=st.complex_numbers(max_magnitude=1e4),
-       D=st.floats(min_value=1e-2, max_value=1e2))
+@given(z=st.complex_numbers(max_magnitude=1e4 if HAS_QUAD else 1e3),
+       D=st.floats(min_value=1e-2 if HAS_QUAD else 1e-1, max_value=1e2))
 def test_bethe_inverse(z, D):
     """Check inverse."""
     if HAS_QUAD:

--- a/gftool/tests/greenfunctions_test.py
+++ b/gftool/tests/greenfunctions_test.py
@@ -864,10 +864,12 @@ def test_bethe_inverse(z, D):
     """Check inverse."""
     if HAS_QUAD:
         assume(z.imag != 0)  # Gf have poles on real axis
+        approx = pytest.approx
     else:
         assume(abs(z.imag) > 1e-8)
+        approx = partial(pytest.approx, rel=1e-4)
     gf = gt.lattice.bethe.gf_z(z, half_bandwidth=D)
-    assert gt.lattice.bethe.gf_z_inv(gf, half_bandwidth=D) == pytest.approx(z)
+    assert gt.lattice.bethe.gf_z_inv(gf, half_bandwidth=D) == approx(z)
 
 
 @pytest.mark.parametrize("D", [1/3, 1.0, 2.0])

--- a/gftool/tests/greenfunctions_test.py
+++ b/gftool/tests/greenfunctions_test.py
@@ -18,6 +18,7 @@ from hypothesis_gufunc.gufunc import gufunc_args
 
 from .context import gftool as gt
 
+HAS_QUAD = gt.precision.HAS_QUAD
 
 nonneg_float = st.floats(min_value=0.)
 pos_float = st.floats(min_value=0., exclude_min=True)
@@ -861,7 +862,10 @@ def test_bethe_derivative_2(z, D):
        D=st.floats(min_value=1e-2, max_value=1e2))
 def test_bethe_inverse(z, D):
     """Check inverse."""
-    assume(z.imag != 0)  # Gf have poles on real axis
+    if HAS_QUAD:
+        assume(z.imag != 0)  # Gf have poles on real axis
+    else:
+        assume(abs(z.imag) > 1e-8)
     gf = gt.lattice.bethe.gf_z(z, half_bandwidth=D)
     assert gt.lattice.bethe.gf_z_inv(gf, half_bandwidth=D) == pytest.approx(z)
 

--- a/gftool/tests/matrix_test.py
+++ b/gftool/tests/matrix_test.py
@@ -13,6 +13,8 @@ from .context import gftool as gt
 
 easy_complex = st.complex_numbers(min_magnitude=1e-2, max_magnitude=1e+2)
 
+HAS_QUAD = gt.precision.HAS_QUAD
+
 
 class TestDecompositionGeneral:
     """Tests for the function `gftool.matrix.decompose_gf`.
@@ -146,7 +148,8 @@ def test_decomposition_inverse(args):
 @given(hopping=st.floats(min_value=-1e6, max_value=1e6),
        eps1=st.floats(min_value=-1e6, max_value=1e6),
        eps0=st.floats(min_value=-1e6, max_value=1e6),
-       z=st.complex_numbers(allow_nan=False, allow_infinity=False))
+       z=st.complex_numbers(allow_nan=False, allow_infinity=False,
+                            max_magnitude=None if HAS_QUAD else 1e64))
 def test_2x2_gf(z, eps0, eps1, hopping):
     """Compare analytic 2x2 Gf vs numeric diagonalization."""
     assume(abs(z.imag) > 1e-6)
@@ -156,8 +159,6 @@ def test_2x2_gf(z, eps0, eps1, hopping):
     dec = gt.matrix.decompose_hamiltonian(ham)
     gf_num = dec.reconstruct(1/(z - dec.eig), kind='diag')
     assert np.allclose(gt.matrix.gf_2x2_z(z, eps0=eps0, eps1=eps1, hopping=hopping), gf_num)
-    if not gt.precision.HAS_QUAD:  # extreme cases require quad, not available for Windows
-        assume(abs(z) < 1e100)
     g0 = partial(gt.bethe_hilbert_transform, half_bandwidth=1)
     gf_num = dec.reconstruct(g0(z - dec.eig), kind='diag')
     gf_2x2 = gt.matrix.gf_2x2_z(z, eps0=eps0, eps1=eps1, hopping=hopping, hilbert_trafo=g0)

--- a/gftool/tests/matrix_test.py
+++ b/gftool/tests/matrix_test.py
@@ -156,6 +156,8 @@ def test_2x2_gf(z, eps0, eps1, hopping):
     dec = gt.matrix.decompose_hamiltonian(ham)
     gf_num = dec.reconstruct(1/(z - dec.eig), kind='diag')
     assert np.allclose(gt.matrix.gf_2x2_z(z, eps0=eps0, eps1=eps1, hopping=hopping), gf_num)
+    if not gt.precision.HAS_QUAD:  # extreme cases require quad, not available for Windows
+        assume(abs(z) < 1e100)
     g0 = partial(gt.bethe_hilbert_transform, half_bandwidth=1)
     gf_num = dec.reconstruct(g0(z - dec.eig), kind='diag')
     gf_2x2 = gt.matrix.gf_2x2_z(z, eps0=eps0, eps1=eps1, hopping=hopping, hilbert_trafo=g0)

--- a/gftool/tests/pade_test.py
+++ b/gftool/tests/pade_test.py
@@ -29,7 +29,10 @@ def test_regression():
     # FIXME: look into different counting
     gf_bethe_old = old_pade.pade_calc(iw=iws, a=coeff_old, w=omega, n_pade=kind[-1]+2)
     gf_bethe = list(kind.islice(gt_pade.calc_iterator(omega, z_in=iws, coeff=coeff)))[-1]
-    assert np.allclose(gf_bethe_old, gf_bethe, rtol=1e-14, atol=1e-14)
+    if gt.precision.HAS_QUAD:
+        assert np.allclose(gf_bethe_old, gf_bethe, rtol=1e-14, atol=1e-14)
+    else:  # reduce test accuracy for Windows
+        assert np.allclose(gf_bethe_old, gf_bethe, rtol=1e-12, atol=1e-14)
 
 
 def test_coeff_type_reduction():


### PR DESCRIPTION
Windows doesn't support quad-precision, so some tests are failing.
Avoid huge numbers and reduce accuracy where necessary to pass the tests.