### PR TITLE
MAINT: NumPy 2 compatibility

### DIFF
--- a/gftool/density.py
+++ b/gftool/density.py
@@ -89,7 +89,7 @@ def density_iw(iws, gf_iw, beta, weights=1., moments=(1.,), n_fit=0):
     True
     """
     # add axis for iws, remove it later at occupation
-    moments = np.asanyarray(moments, dtype=np.float_)[..., np.newaxis, :]
+    moments = np.asanyarray(moments, dtype=np.float64)[..., np.newaxis, :]
     if n_fit:
         n_mom = moments.shape[-1]
         weight = iws.imag**(n_mom+n_fit)

--- a/gftool/lattice/bcc.py
+++ b/gftool/lattice/bcc.py
@@ -154,7 +154,7 @@ def dos(eps, half_bandwidth):
     m = 0.5 - 0.5j*np.sqrt(eps_rel[finite]**-2 - 1)
     Ksqr = _u_ellipk(m)**2
     dos_[finite] = -4 / (np.pi**3 * abs(eps[finite])) * Ksqr.imag
-    dos_[singular] = np.infty
+    dos_[singular] = np.inf
     return dos_
 
 

--- a/gftool/lattice/fcc.py
+++ b/gftool/lattice/fcc.py
@@ -178,7 +178,7 @@ def dos(eps, half_bandwidth):
     finite = (-0.5*half_bandwidth < eps) & (eps < 1.5*half_bandwidth) & ~singular
     dos_ = np.zeros_like(eps)
     dos_[finite] = 1 / np.pi * gf_z(eps[finite], half_bandwidth=half_bandwidth).imag
-    dos_[singular] = np.infty
+    dos_[singular] = np.inf
     return abs(dos_)  # at 0.5D wrong sign
 
 

--- a/gftool/lattice/triangular.py
+++ b/gftool/lattice/triangular.py
@@ -86,7 +86,7 @@ def gf_z(z, half_bandwidth):
     # eqs (2.22) and eq (2.18), fix correct plane
     K[kk.imag > 0] += 2j*_u_ellipk(1 - mm[kk.imag > 0])
     gf_z = 1 / np.pi / D * gg * K  # eq (2.6)
-    gf_z[singular] = 0 - 1j*np.infty
+    gf_z[singular] = 0 - 1j*np.inf
     return np.where(advanced, np.conj(gf_z), gf_z).reshape(shape)  # return to advanced by symmetry
 
 

--- a/gftool/pade.py
+++ b/gftool/pade.py
@@ -336,7 +336,7 @@ def masked_coefficients(z, fct_z):
                 elif abs(last_coeff) < abs(mat[last_it, jj])*cutoff:  # tiny quotient
                     mat_pi[jj] = (-1)/(z[jj] - z[last_it])
                 else:  # huge quotient
-                    mat_pi[jj] = np.infty
+                    mat_pi[jj] = np.inf
             last_it = ii
             last_coeff = mat_pi[ii]
         else:

--- a/gftool/precision.py
+++ b/gftool/precision.py
@@ -15,9 +15,9 @@ except AttributeError:
     HAS_QUAD = False
     warnings.warn("No quad precision datatypes available!\n"
                   "Some functions might be less accurate.")
-    np.float128 = np.longfloat
-    np.complex256 = np.clongfloat
+    np.float128 = np.longdouble
+    np.complex256 = np.clongdouble
 else:
     HAS_QUAD = True
 
-PRECISE_TYPES = {np.dtype(np.longfloat), np.dtype(np.clongfloat)}
+PRECISE_TYPES = {np.dtype(np.longdouble), np.dtype(np.clongdouble)}

--- a/gftool/statistics.py
+++ b/gftool/statistics.py
@@ -234,7 +234,7 @@ def _pade_frequencies(num: int):
     """Temperature independent part, useful for caching."""
     num = 2*num
     a = -np.diagflat(range(1, 2*num, 2))
-    b = np.zeros_like(a, dtype=np.float_)
+    b = np.zeros_like(a, dtype=np.float64)
     np.fill_diagonal(b[1:, :], 0.5)
     np.fill_diagonal(b[:, 1:], 0.5)
     eig, v = linalg.eig(a, b=b, overwrite_a=True, overwrite_b=True)

--- a/gftool/tests/basis_test.py
+++ b/gftool/tests/basis_test.py
@@ -12,7 +12,7 @@ assert_allclose = np.testing.assert_allclose
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-@given(gufunc_args('(n)->(n)', dtype=np.complex_, elements=st.complex_numbers()))
+@given(gufunc_args('(n)->(n)', dtype=np.complex128, elements=st.complex_numbers()))
 def test_zp_to_ratpol(args):
     """Check that `gt.basis.ZeroPole` and `gt.basis.RatPol` give same result."""
     z, = args

--- a/gftool/tests/cpa_test.py
+++ b/gftool/tests/cpa_test.py
@@ -24,7 +24,7 @@ ignore_illconditioned = pytest.mark.filterwarnings(
 
 
 @given(gufunc_args(
-    '(n)->(n)', dtype=np.complex_,
+    '(n)->(n)', dtype=np.complex128,
     elements=st.complex_numbers(allow_infinity=False, allow_nan=False,
                                 max_magnitude=None if HAS_QUAD else 1e100)
 ))

--- a/gftool/tests/fourier_test.py
+++ b/gftool/tests/fourier_test.py
@@ -21,7 +21,7 @@ from .context import assert_allclose_vm
 assert_allclose = np.testing.assert_allclose
 
 
-@given(gufunc_args('(n)->(n),(m)', dtype=np.float_,
+@given(gufunc_args('(n)->(n),(m)', dtype=np.float64,
                    elements=st.floats(min_value=-1e6, max_value=1e6),
                    max_dims_extra=2, max_side=10),)
 def test_gf_form_moments(args):
@@ -72,7 +72,7 @@ def test_iw2tau_dft_single_pole(pole):
     assert_allclose(gf_tau, gf_dft, atol=1e-3, rtol=1e-4)
 
 
-@given(gufunc_args('(n),(n)->(l)', dtype=np.float_,
+@given(gufunc_args('(n),(n)->(l)', dtype=np.float64,
                    elements=[st.floats(min_value=-10, max_value=10),
                              st.floats(min_value=0, max_value=10)],
                    max_dims_extra=1, max_side=5),)
@@ -172,7 +172,7 @@ def test_tau2iw_dft_single_pole(pole):
     assert_allclose(gf_iw, gf_dft, atol=1e-4)
 
 
-@given(gufunc_args('(n),(n)->(l)', dtype=np.float_,
+@given(gufunc_args('(n),(n)->(l)', dtype=np.float64,
                    elements=[st.floats(min_value=-10, max_value=10),
                              st.floats(min_value=0, max_value=10)],
                    max_dims_extra=1, max_side=5),)
@@ -201,7 +201,7 @@ def test_tau2iw_multi_pole(args):
     assert_allclose(gf_iw, gf_ft, rtol=1e-4)
 
 
-@given(gufunc_args('(n),(n)->(l)', dtype=np.float_,
+@given(gufunc_args('(n),(n)->(l)', dtype=np.float64,
                    elements=[st.floats(min_value=-10, max_value=10),
                              st.floats(min_value=0, max_value=10)],
                    max_dims_extra=1, max_side=5),)
@@ -224,7 +224,7 @@ def test_tau2iw_multi_pole_hfm(args):
     assert_allclose(gf_iw, gf_ft, rtol=1e-4)
 
 
-@given(gufunc_args('(n)->(n)', dtype=np.float_,
+@given(gufunc_args('(n)->(n)', dtype=np.float64,
                    elements=st.floats(min_value=-1e6, max_value=1e6),
                    max_dims_extra=2, max_side=10),)
 def test_pole_from_gftau_exact(args):
@@ -343,7 +343,7 @@ def test_simps_weights(test_fct):
         assert_allclose(coeff.sum(), np.trapz(gf, dx=dt), rtol=1e-14)
 
 
-@given(gufunc_args('(n),(n)->(l)', dtype=np.float_,
+@given(gufunc_args('(n),(n)->(l)', dtype=np.float64,
                    elements=[st.floats(min_value=-10, max_value=10),
                              st.floats(min_value=0, max_value=10), ],
                    max_dims_extra=2, max_side=5),)
@@ -414,7 +414,7 @@ def test_tt2z_single_pole_nonumexpr(spole):
         gt.fourier._phase = gt.fourier._phase_numexpr
 
 
-@given(gufunc_args('(n),(n)->(l)', dtype=np.float_,
+@given(gufunc_args('(n),(n)->(l)', dtype=np.float64,
                    elements=[st.floats(min_value=-1, max_value=1),
                              st.floats(min_value=0, max_value=10), ],
                    max_dims_extra=2, max_side=5),)
@@ -447,7 +447,7 @@ def test_tt2z_multi_pole(args):
     gt.fourier.tt2z(tt[::10], gf_t[..., ::10], ww, laplace=gt.fourier.tt2z_lin)
 
 
-@given(gufunc_args('(l),(n),(n)->(l)', dtype=np.complex_,
+@given(gufunc_args('(l),(n),(n)->(l)', dtype=np.complex128,
                    elements=[st.complex_numbers(max_magnitude=2),
                              st.floats(min_value=-1, max_value=1),
                              st.floats(min_value=0, max_value=10), ],
@@ -477,7 +477,7 @@ def test_tt2z_gufuncz(args):
     assert_allclose(gf_z, gf_ft, rtol=1e-3)
 
 
-@given(gufunc_args('(l),(n),(n)->(l)', dtype=np.complex_,
+@given(gufunc_args('(l),(n),(n)->(l)', dtype=np.complex128,
                    elements=[st.floats(min_value=-1,  max_value=1),
                              st.floats(min_value=-1, max_value=1),
                              st.floats(min_value=0, max_value=10), ],
@@ -536,7 +536,7 @@ def test_tt2z_pade_box(fast):
     assert_allclose(gf_fp[~inner], gf_ww[~inner], rtol=0.3 if fast else 0.2)
 
 
-@given(gufunc_args('(l),(n),(n)->(l)', dtype=np.complex_,
+@given(gufunc_args('(l),(n),(n)->(l)', dtype=np.complex128,
                    elements=[st.floats(min_value=-1,  max_value=1),
                              st.floats(min_value=-1, max_value=1),
                              st.floats(min_value=0, max_value=10), ],

--- a/gftool/tests/greenfunctions_test.py
+++ b/gftool/tests/greenfunctions_test.py
@@ -66,7 +66,7 @@ class GfProperties:
         Can be overwritten by subclasses using the `params`.
         """
         del params
-        return -np.infty, np.infty
+        return -np.inf, np.inf
 
     def test_complex(self, params):
         r""":math:`G_{AB}^*(z) = G_{B^† A^†}(z^*)`."""
@@ -76,11 +76,11 @@ class GfProperties:
     def test_limit(self, params):
         r""":math:`\lim_{z→∞} zG(z) = 1`."""
         assert_allclose(  # along real axis
-            fp.limit(lambda zz: zz*self.gf(zz, *params[0], **params[1]).real, np.infty), 1,
+            fp.limit(lambda zz: zz*self.gf(zz, *params[0], **params[1]).real, np.inf), 1,
             rtol=1e-2
         )
         assert_allclose(  # along imaginary axis
-            fp.limit(lambda zz: -zz*self.gf(1j*zz, *params[0], **params[1]).imag, np.infty), 1,
+            fp.limit(lambda zz: -zz*self.gf(1j*zz, *params[0], **params[1]).imag, np.inf), 1,
             rtol=1e-2
         )
 
@@ -124,7 +124,7 @@ class Lattice:
         Can be overwritten by subclasses using the `kwds`.
         """
         del kwds
-        return -np.infty, np.infty
+        return -np.inf, np.inf
 
     @staticmethod
     def singularities(**kwds):
@@ -842,11 +842,11 @@ class TestHubbardDimer(GfProperties):
     def test_limit(self, params):
         """Limit of Pols cannot be accurately determined, thus accuracy is reduced."""
         assert_allclose(  # along real axis
-            fp.limit(lambda zz: zz*self.gf(zz, *params[0], **params[1]).real, np.infty), 1,
+            fp.limit(lambda zz: zz*self.gf(zz, *params[0], **params[1]).real, np.inf), 1,
             rtol=1e-1
         )
         assert_allclose(  # along imaginary axis
-            fp.limit(lambda zz: -zz*self.gf(1j*zz, *params[0], **params[1]).imag, np.infty), 1,
+            fp.limit(lambda zz: -zz*self.gf(1j*zz, *params[0], **params[1]).imag, np.inf), 1,
             rtol=1e-2
         )
 
@@ -903,7 +903,7 @@ def test_bethe_retarded(D, center):
     assert_allclose(gf_ft, gf_ww, rtol=1e-4, atol=1e-5)
 
 
-@given(gufunc_args('(),(),()->()', dtype=np.float_,
+@given(gufunc_args('(),(),()->()', dtype=np.float64,
                    elements=[st.floats(0, 10),
                              st.floats(0.1, 10),
                              st.floats(0, 10),
@@ -996,7 +996,7 @@ def test_simplecubic_gf_vs_gf_mp(z, D):
 
 @pytest.mark.filterwarnings("ignore:(invalid value)|(overflow)|(divide by zero):RuntimeWarning")
 @given(gufunc_args('(),(N),(N)->()',
-                   dtype=[np.complex_, np.float_, np.float_],
+                   dtype=[np.complex128, np.float64, np.float64],
                    elements=[st.complex_numbers(), st.floats(), st.floats()],
                    max_dims_extra=3)
        )
@@ -1010,7 +1010,7 @@ def test_pole_gf_z_gu(args):
 
 @pytest.mark.filterwarnings("ignore:(invalid value)|(overflow):RuntimeWarning")
 @given(gufunc_args('(),(N),(N),()->()',
-                   dtype=[np.float_, np.float_, np.float_, np.float_],
+                   dtype=[np.float64, np.float64, np.float64, np.float64],
                    elements=[st.floats(min_value=0., max_value=1.),
                              st.floats(), nonneg_float, nonneg_float],
                    max_dims_extra=3)
@@ -1027,7 +1027,7 @@ def test_pole_gf_tau_gu(args):
 
 @pytest.mark.filterwarnings("ignore:(invalid value)|(overflow)|(devide by zero):RuntimeWarning")
 @given(gufunc_args('(),(N),(N),()->()',
-                   dtype=[np.float_, np.float_, np.float_, np.float_],
+                   dtype=[np.float64, np.float64, np.float64, np.float64],
                    elements=[st.floats(min_value=0., max_value=1.),
                              pos_float, nonneg_float, pos_float],
                    max_dims_extra=3)
@@ -1068,14 +1068,14 @@ def test_hubbard_I_self_hfm():
     U, occ = 1.7, 0.3
     hubbard_I = partial(gt.hubbard_I_self_z, U=U, occ=occ)
     m0 = U*occ
-    limit_0p = fp.limit(hubbard_I, np.infty, exp=True)
+    limit_0p = fp.limit(hubbard_I, np.inf, exp=True)
     assert limit_0p == pytest.approx(m0)
 
     def hubbard_dyn(z):
         return z*(hubbard_I(z) - m0)
 
     m1 = occ * (1 - occ) * U**2
-    limit_1p = fp.limit(hubbard_dyn, np.infty, exp=True, steps=[25])
+    limit_1p = fp.limit(hubbard_dyn, np.inf, exp=True, steps=[25])
     assert limit_1p == pytest.approx(m1)
 
 
@@ -1146,7 +1146,7 @@ def test_box_retarded(D, center):
     assert_allclose(gf_ft, gf_ww, rtol=1e-4, atol=1e-5)
 
 
-@given(gufunc_args('(),(),()->()', dtype=np.float_,
+@given(gufunc_args('(),(),()->()', dtype=np.float64,
                    elements=[st.floats(0, 10),
                              st.floats(0.1, 10),
                              st.floats(0, 10),

--- a/gftool/tests/linalg_test.py
+++ b/gftool/tests/linalg_test.py
@@ -13,7 +13,7 @@ assert_allclose = np.testing.assert_allclose
 easy_complex = st.complex_numbers(min_magnitude=1e-2, max_magnitude=1e+2)
 
 
-@given(gufunc_args('(m,n)->(k,m)', dtype=np.complex_, elements=easy_complex,
+@given(gufunc_args('(m,n)->(k,m)', dtype=np.complex128, elements=easy_complex,
                    max_dims_extra=0, max_side=10),)
 def test_orth_compl(args):
     """Test that orthogonal complement is orthogonal."""
@@ -24,7 +24,7 @@ def test_orth_compl(args):
     assert_allclose(perp@mat, 0, atol=1e-12)
 
 
-@given(gufunc_args('(m,n),(m),(n,n),(n)->(n)', dtype=np.complex_, elements=easy_complex,
+@given(gufunc_args('(m,n),(m),(n,n),(n)->(n)', dtype=np.complex128, elements=easy_complex,
                    max_dims_extra=0, max_side=5),)
 def test_lstsq_ce_constraints(args):
     """Check if fully constraint solution of `gt.linalg.lstsq_ec` is correct."""
@@ -37,7 +37,7 @@ def test_lstsq_ce_constraints(args):
 
 
 @pytest.mark.skip("Can't get this test working...")
-@given(gufunc_args('(m,n),(m),(l,n),(l)->(n)', dtype=np.complex_, elements=easy_complex,
+@given(gufunc_args('(m,n),(m),(l,n),(l)->(n)', dtype=np.complex128, elements=easy_complex,
                    max_dims_extra=0, max_side=5),)
 def test_lstsq_ce(args):
     """Check if solution of `gt.linalg.lstsq_ec` fulfills constraints."""
@@ -74,7 +74,7 @@ def test_singular_constraint():
     assert_allclose(np.sum(c*lstsq, axis=-1), d)
 
 
-@given(gufunc_args('(m,n),(m)->(n)', dtype=np.complex_, elements=easy_complex,
+@given(gufunc_args('(m,n),(m)->(n)', dtype=np.complex128, elements=easy_complex,
                    max_dims_extra=0, max_side=5),)
 def test_lstsq_ce_is_lstq(args):
     """Check if solution of `gt.linalg.lstsq_ec` is a least-squares solution."""

--- a/gftool/tests/linearprediction_test.py
+++ b/gftool/tests/linearprediction_test.py
@@ -13,7 +13,7 @@ lp = gt.linearprediction
 assert_allclose = np.testing.assert_allclose
 
 
-@given(a=hnp.arrays(np.float_,
+@given(a=hnp.arrays(np.float64,
                     shape=hnp.array_shapes(min_side=2),
                     elements=st.floats(1e+6, 1e+6))
        )
@@ -117,7 +117,7 @@ def test_lattice_prediction(fraction, lattice, stable):
 
 
 @pytest.mark.parametrize("method, atol", [(lp.pcoeff_covar, 1e-6)])
-@given(gufunc_args('(n),(n)->()', dtype=np.float_,
+@given(gufunc_args('(n),(n)->()', dtype=np.float64,
                    elements=[st.floats(min_value=-1, max_value=1),
                              st.floats(min_value=0, max_value=10),
                              ],

--- a/gftool/tests/matrix_test.py
+++ b/gftool/tests/matrix_test.py
@@ -83,7 +83,7 @@ class TestDecompositionGeneral:
 
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-@given(gufunc_args('(n,n)->(n,n)', dtype=np.complex_, elements=easy_complex,
+@given(gufunc_args('(n,n)->(n,n)', dtype=np.complex128, elements=easy_complex,
                    max_dims_extra=2, max_side=4),)
 def test_decomposition_reconsturction(args):
     """Check if the reconstruction using `gt.matrix.Decomposition` is correct."""
@@ -116,7 +116,7 @@ def test_decomposition_reconsturction(args):
 
 @pytest.mark.filterwarnings("ignore:(overflow)|(invalid value):RuntimeWarning")
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-@given(gufunc_args('(n,n)->(n,n)', dtype=np.complex_, elements=easy_complex,
+@given(gufunc_args('(n,n)->(n,n)', dtype=np.complex128, elements=easy_complex,
                    max_dims_extra=2, max_side=4),)
 def test_decomposition_inverse(args):
     """Check if the inverse using `gt.matrix.Decomposition` is correct."""

--- a/gftool/tests/siam_test.py
+++ b/gftool/tests/siam_test.py
@@ -12,7 +12,7 @@ assert_allclose = np.testing.assert_allclose
 
 
 @pytest.mark.filterwarnings("ignore:(overflow):RuntimeWarning")
-@given(gufunc_args('(),(n),(n)->(l)', dtype=np.float_,
+@given(gufunc_args('(),(n),(n)->(l)', dtype=np.float64,
                    elements=[st.floats(min_value=-1, max_value=1),
                              st.floats(min_value=-1, max_value=1),
                              st.floats(min_value=+0, max_value=1),
@@ -31,7 +31,7 @@ def test_gf_loc_z_vs_resolvent(args, z):
     assert_allclose(gf0_loc_z, resolvent[..., 0, 0])
 
 
-@given(gufunc_args('(),(n),(n)->(l)', dtype=np.float_,
+@given(gufunc_args('(),(n),(n)->(l)', dtype=np.float64,
                    elements=[st.floats(min_value=-1, max_value=1),
                              st.floats(min_value=-1, max_value=1),
                              st.floats(min_value=+0, max_value=1),
@@ -50,7 +50,7 @@ def test_consistency_gf_loc_z_vs_ret_t(args):
     assert_allclose(gf0_loc_z, gf0_ft_z, rtol=1e-3, atol=1e-4)
 
 
-@given(gufunc_args('(),(),(n),(n)->(l)', dtype=np.float_,
+@given(gufunc_args('(),(),(n),(n)->(l)', dtype=np.float64,
                    elements=[st.floats(min_value=+0, max_value=1000),
                              st.floats(min_value=-1, max_value=1),
                              st.floats(min_value=-1, max_value=1),

--- a/gftool/tests/utilities_test.py
+++ b/gftool/tests/utilities_test.py
@@ -19,8 +19,8 @@ assert_allclose = np.testing.assert_allclose
 
 def test_bose_edge_cases():
     """Check exact limits at `0` and `np.infty`."""
-    assert gt.bose_fct(0., 1) == np.infty
-    assert gt.bose_fct(np.infty, 1) == 0
+    assert gt.bose_fct(0., 1) == np.inf
+    assert gt.bose_fct(np.inf, 1) == 0
 
 
 @given(z=st.floats(min_value=1e-4, max_value=1e4), n=st.integers(min_value=-100, max_value=100))
@@ -152,7 +152,7 @@ def test_density():
     assert_allclose(gt.density_iw(iws, 1./iws, moments=[1., 0], beta=beta), 0.5)
 
 
-@given(args=gufunc_args('(n),(n)->(n)', dtype=np.float_,
+@given(args=gufunc_args('(n),(n)->(n)', dtype=np.float64,
                         elements=[st.floats(min_value=-10, max_value=10),
                                   st.floats(min_value=0, max_value=10)]
                         ),)
@@ -188,7 +188,7 @@ def pade_frequencies():
     return pade_frequencies_
 
 
-@given(args=gufunc_args('(n),(n)->(n)', dtype=np.float_,
+@given(args=gufunc_args('(n),(n)->(n)', dtype=np.float64,
                         elements=[st.floats(min_value=-10, max_value=10),
                                   st.floats(min_value=0, max_value=10)]
                         ),)


### PR DESCRIPTION
NumPy 2 mainly cleanses up namespaces. Switch to future-prove names.