### PR TITLE
DOC: clean up sphinx configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,8 @@ jobs:
           python-version: "3.10"
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip wheel
-          pip install -r requirements-doc.txt
-          pip install .
+          python -m pip install --upgrade pip
+          pip install .[docs]
       - name: Test documentation
         run: |
           sphinx-build -d docs/build/doctrees docs/source docs/build/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,8 +10,7 @@ build:
 
 python:
   install:
-    - requirements: docs/source/requirements.txt
-    - path: .
+    - path: .[docs]
 
 formats:
   - htmlzip

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ If you clone the project, you can locally build the documentation:
 
 .. code-block:: console
 
-   $ pip install -r requirements-doc.txt
+   $ pip install .[docs]
    $ sphinx-build docs/source docs/build/html
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,9 +14,6 @@ https://www.sphinx-doc.org/en/master/usage/configuration.html
 #
 import math
 import os
-import sys
-
-sys.path.insert(0, os.path.abspath('../..'))  # noqa: PTH100
 
 import gftool
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -72,7 +72,7 @@ If you clone the project, you can locally build the documentation:
 
 .. code-block:: console
 
-   $ pip install -r requirements-doc.txt
+   $ pip install .[docs]
    $ sphinx-build docs/source docs/build/html
 
 

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,5 +1,0 @@
-matplotlib
-numpydoc>=1.2.0,<1.9  # needed for validation
-sphinx>3.0.0   # https://github.com/readthedocs/readthedocs.org/issues/8616
-sphinx-rtd-theme>0.5.0
-sphinx-toggleprompt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,13 @@ dependencies = [
 [project.optional-dependencies]
 test = ['pytest>=4.6', 'hypothesis>=4.24.5']
 fast = ['numexpr']
+docs = [
+  'matplotlib',
+  'numpydoc>=1.2,<1.9',
+  'sphinx>=5.0,<8.0',
+  'sphinx-toggleprompt',
+  'sphinx_rtd_theme>0.5',
+]
 
 [project.urls]
 ReadTheDocs = "https://gftools.readthedocs.io/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ fast = ['numexpr']
 docs = [
   'matplotlib',
   'numpydoc>=1.2,<1.9',
-  'sphinx>=5.0,<8.0',
+  'sphinx>=5.0,<9.0',
   'sphinx-toggleprompt',
   'sphinx_rtd_theme>0.5',
 ]

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,5 +1,0 @@
-matplotlib
-numpydoc>=1.2.0,<1.9  # needed for validation
-sphinx>=5.0.0,<8.0
-sphinx-toggleprompt
-sphinx_rtd_theme

--- a/whats-new.rst
+++ b/whats-new.rst
@@ -1,5 +1,3 @@
-.. currentmodule:: gftool
-
 What's New
 ==========
 


### PR DESCRIPTION
* Use installed `gftool` module instead of relying on path hacks.
* Manage documentation dependencies with `pyproject.toml`